### PR TITLE
Using urllib.parse instead of urllib2, and catching some edge cases

### DIFF
--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -300,3 +300,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -105,7 +105,7 @@ def node_to_post(node):
     except ValueError:
         logging.getLogger().debug("Processing post #%s", post['id'])
 
-    if post['text'] != None:
+    if post['text'] is not None:
         post['text'] = post['text'].replace('\r\n', '\n')
         post['text'] = post['text'].replace('\n', '#$NEWLINE-MARKER$#')
         post['text'] = html_to_org(post['text'].encode('utf8')).decode('utf8')
@@ -155,13 +155,13 @@ def link_to_file(link):
     name = '%s.org' % unquote(name)
     return name
 
-def parse_date(date, format):
+def parse_date(date, date_format):
     """Change wp date format to a different format."""
 
-    if date != None:
+    if date is not None:
         date = date.split('+')[0].strip()
         date = strptime(date, '%a, %d %b %Y %H:%M:%S')
-        date = strftime(format, date)
+        date = strftime(date_format, date)
 
     return date
 

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """wp_to_org2blog.py: Convert wordpress.xml to org2blog posts.
 

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -100,9 +100,9 @@ def node_to_post(node):
 
     try:
         if int(post['id']) % 10 == 0:
-            logging.getLogger().info("Processing post #%s" % post['id'])
+            logging.getLogger().info("Processing post #%s", post['id'])
     except ValueError:
-        logging.getLogger().debug("Processing post #%s" % post['id'])
+        logging.getLogger().debug("Processing post #%s", post['id'])
 
     if post['text'] != None:
         post['text'] = post['text'].replace('\r\n', '\n')

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -94,7 +94,7 @@ def node_to_post(node):
     try:
         if int(post['id']) % 10 == 0:
             logging.getLogger().info("Processing post #%s" % post['id'])
-    except:
+    except ValueError:
         logging.getLogger().debug("Processing post #%s" % post['id'])
 
     if post['text'] != None:

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -70,7 +70,7 @@ def html_to_org(html):
     proc = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
     output, error = proc.communicate(html)
 
-    if (proc.returncode != 0) or (error is not None):
+    if (proc.returncode != 0) or (error != b""):
         errormessage = """%s exited with return code %s and error %s when parsing:
             %s"""
         raise SubprocessError(errormessage % (args[0], proc.returncode, error, html))

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -201,9 +201,8 @@ def blog_to_org(blog_list, name, level, buffer, prefix):
 
     f.close()
 
-if __name__ == "__main__":
-
-    import argparse
+def main():
+    """Main function; meant to be executed when the script is called from CLI."""
     parser = argparse.ArgumentParser(
         description='Convert wordpress.xml to org2blog posts.')
 
@@ -232,3 +231,7 @@ if __name__ == "__main__":
                 args.prefix_date)
 
     logger.warning("Done!")
+
+
+if __name__ == "__main__":
+    main()

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -139,7 +139,6 @@ def xml_to_list(infile):
     blog = list()  # list that will contain all posts
 
     for node in dom.getElementsByTagName('item'):
-        post = dict()
 
         post = node_to_post( node )
 
@@ -184,7 +183,7 @@ def blog_to_org(blog_list, name, level, buffer, prefix):
     else:
         template = SUBTREE_TEMPLATE
         tag_sep = ':'
-        org_file = open('%s.org' % name, 'w')
+        org_file = open('%s.org' % name, 'wb')
 
     for post in blog_list:
         post['tags'] = tag_sep.join(post['tags'])
@@ -211,7 +210,7 @@ def blog_to_org(blog_list, name, level, buffer, prefix):
             if not os.path.exists(name):
                 os.mkdir(name)
             else:
-                org_file = open(os.path.join(name, file_name), 'w')
+                org_file = open(os.path.join(name, file_name), 'wb')
                 org_file.write(post_output.encode('utf8'))
                 org_file.close()
         else:

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -31,6 +31,7 @@ import logging
 
 from time import strptime, strftime
 from xml.dom import minidom
+from xml.parsers.expat import ExpatError
 from subprocess import Popen, PIPE, SubprocessError
 from shlex import split
 from urllib.parse import unquote
@@ -138,7 +139,11 @@ def xml_to_list(infile):
     Each post is a dictionary.
     """
 
-    dom = minidom.parse(infile)
+    try:
+        dom = minidom.parse(infile)
+    except ExpatError as err:
+        print("Error while parsing %s: %s" % (infile, err))
+        raise
 
     blog = list()  # list that will contain all posts
 

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -78,6 +78,7 @@ def html_to_org(html):
     return output
 
 def get_firstChild_data(node, element):
+    """Try to retrieve the data contained at a node's firstChild element."""
     try:
         return node.getElementsByTagName(element)[0].firstChild.data
     except (AttributeError, IndexError):

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -32,7 +32,7 @@ from time import strptime, strftime
 from xml.dom import minidom
 from subprocess import Popen, PIPE
 from shlex import split
-from urllib2 import unquote
+from urllib.parse import unquote
 
 SUBTREE_TEMPLATE = u"""\
 %(stars)s %(title)s %(tags)s

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -65,27 +65,29 @@ def html_to_org(html):
     command = 'pandoc -r html -t org --wrap=none -'
     args = split(command)
 
-    p = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-    output, error = p.communicate(html)
+    proc = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    output, error = proc.communicate(html)
 
-    if (p.returncode != 0) or (error is not None):
+    if (proc.returncode != 0) or (error is not None):
         errormessage = """%s exited with return code %s and error %s when parsing:
             %s"""
         raise SubprocessError(
-            errormessage % (args[0], p.returncode, error, html)
+            errormessage % (args[0], proc.returncode, error, html)
         )
 
     return output
 
-def get_firstChild_data(node, element):
-    """Try to retrieve the data contained at a node's firstChild element."""
+def get_first_child_data(node, tag_name):
+    """Try to retrieve the data contained at a node's tag's firstChild."""
     try:
-        return node.getElementsByTagName(element)[0].firstChild.data
+        return node.getElementsByTagName(tag_name)[0].firstChild.data
     except (AttributeError, IndexError):
         return None
 
 def node_to_post(node):
     """Takes an XML node from the export and converts it to a dict"""
+
+    # key: (XML) tag_name
     key_map = {
         'title': 'title',
         'link': 'link',
@@ -96,8 +98,8 @@ def node_to_post(node):
     }
     post = dict()
 
-    for key, el in key_map.items():
-        post[key] = get_firstChild_data(node, el)
+    for key, tag_name in key_map.items():
+        post[key] = get_first_child_data(node, tag_name)
 
     try:
         if int(post['id']) % 10 == 0:
@@ -178,7 +180,7 @@ def blog_to_org(blog_list, name, level, buffer, prefix):
     else:
         template = SUBTREE_TEMPLATE
         tag_sep = ':'
-        f = open('%s.org' % name, 'w')
+        org_file = open('%s.org' % name, 'w')
 
     for post in blog_list:
         post['tags'] = tag_sep.join(post['tags'])
@@ -202,13 +204,13 @@ def blog_to_org(blog_list, name, level, buffer, prefix):
             if not os.path.exists(name):
                 os.mkdir(name)
             else:
-                f = open(os.path.join(name, file_name), 'w')
-                f.write(post_output.encode('utf8'))
-                f.close()
+                org_file = open(os.path.join(name, file_name), 'w')
+                org_file.write(post_output.encode('utf8'))
+                org_file.close()
         else:
-            f.write(post_output.encode('utf8'))
+            org_file.write(post_output.encode('utf8'))
 
-    f.close()
+    org_file.close()
 
 def main():
     """Main function; meant to be executed when the script is called from CLI."""
@@ -227,8 +229,8 @@ def main():
 
     args = parser.parse_args()
 
-    FORMAT = '%(message)s'
-    logging.basicConfig(format=FORMAT, level=logging.INFO)
+    logging_format = '%(message)s'
+    logging.basicConfig(format=logging_format, level=logging.INFO)
     logger = logging.getLogger()
 
 

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -116,7 +116,8 @@ def node_to_post(node):
         post['text'] = ''
 
     # Get the tags and categories
-    post['tags'], post['categories'] = [], []
+    post['tags'] = list()
+    post['categories'] = list()
 
     for element in node.getElementsByTagName('category'):
         domain, name = element.getAttribute('domain'), element.getAttribute('nicename')
@@ -135,7 +136,7 @@ def xml_to_list(infile):
 
     dom = minidom.parse(infile)
 
-    blog = [] # list that will contain all posts
+    blog = list()  # list that will contain all posts
 
     for node in dom.getElementsByTagName('item'):
         post = dict()
@@ -173,7 +174,10 @@ def blog_to_org(blog_list, name, level, buffer, prefix):
     space = ' ' * level
     stars = '*' * level
 
-    tag_sep = cat_sep = ', '
+    tag_sep = ', '
+    cat_sep = ', '
+
+    template_parts = dict()
 
     if buffer:
         template = BUFFER_TEMPLATE
@@ -193,7 +197,10 @@ def blog_to_org(blog_list, name, level, buffer, prefix):
         if not buffer:
             post['text'] = post['text'].replace('\n', '\n %s' % space)
 
-        post_output = template % dict(post, **{'space': space, 'stars': stars})
+        template_parts.update(**post)
+        template_parts.update(space=space)
+        template_parts.update(stars=stars)
+        post_output = template % template_parts
 
         if buffer:
             if prefix:


### PR DESCRIPTION
Summary of commits:
- Added newline at end of file
- Fixed rebase
- Changed shebang to use python3
- Added try statement to catch malformed XML
- Corrected to compare to regular binary empty string
- Reformatted with black
- Include workaround for posts with id or query ('?p=123') in URL
- Fixed builtins.TypeError: must be str, not bytes
- Switched to more verbose instructions
- Clarified variable names and used snake_case
- Avoided using builtin
- Added function docstring; fixed None comparisons
- Corrected lazy formatting for logger
- Fixed indentation logic; specified errors to raise or catch
- Added exception type
- Move main actions into main function; don't re-import argparse
- Use urllib.parse instead of urllib2
