### PR TITLE
Using urllib.parse instead of urllib2, and catching some edge cases

### DIFF
--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -272,3 +272,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -60,10 +60,11 @@ BUFFER_TEMPLATE = u"""\
 
 """
 
+
 def html_to_org(html):
     """Converts a html snippet to an org-snippet."""
 
-    command = 'pandoc -r html -t org --wrap=none -'
+    command = "pandoc -r html -t org --wrap=none -"
     args = split(command)
 
     proc = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
@@ -72,11 +73,10 @@ def html_to_org(html):
     if (proc.returncode != 0) or (error is not None):
         errormessage = """%s exited with return code %s and error %s when parsing:
             %s"""
-        raise SubprocessError(
-             errormessage % (args[0], proc.returncode, error, html)
-        )
+        raise SubprocessError(errormessage % (args[0], proc.returncode, error, html))
 
     return output
+
 
 def get_first_child_data(node, tag_name):
     """Try to retrieve the data contained at a node's tag's firstChild."""
@@ -85,18 +85,19 @@ def get_first_child_data(node, tag_name):
     except (AttributeError, IndexError):
         return None
 
+
 def node_to_post(node):
     """Takes an XML node from the export and converts it to a dict"""
 
     # key: (XML) tag_name
     key_map = {
-        'title': 'title',
-        'link': 'link',
-        'date': 'pubDate',
-        'author': 'dc:creator',
-        'id': 'wp:post_id',
-        'text': 'content:encoded',
-        'post_name': 'wp:post_name'
+        "title": "title",
+        "link": "link",
+        "date": "pubDate",
+        "author": "dc:creator",
+        "id": "wp:post_id",
+        "text": "content:encoded",
+        "post_name": "wp:post_name",
     }
     post = dict()
 
@@ -104,32 +105,33 @@ def node_to_post(node):
         post[key] = get_first_child_data(node, tag_name)
 
     try:
-        if int(post['id']) % 10 == 0:
-            logging.getLogger().info("Processing post #%s", post['id'])
+        if int(post["id"]) % 10 == 0:
+            logging.getLogger().info("Processing post #%s", post["id"])
     except ValueError:
-        logging.getLogger().debug("Processing post #%s", post['id'])
+        logging.getLogger().debug("Processing post #%s", post["id"])
 
-    if post['text'] is not None:
-        post['text'] = post['text'].replace('\r\n', '\n')
-        post['text'] = post['text'].replace('\n', '#$NEWLINE-MARKER$#')
-        post['text'] = html_to_org(post['text'].encode('utf8')).decode('utf8')
-        post['text'] = post['text'].replace('#$NEWLINE-MARKER$#', '\n')
+    if post["text"] is not None:
+        post["text"] = post["text"].replace("\r\n", "\n")
+        post["text"] = post["text"].replace("\n", "#$NEWLINE-MARKER$#")
+        post["text"] = html_to_org(post["text"].encode("utf8")).decode("utf8")
+        post["text"] = post["text"].replace("#$NEWLINE-MARKER$#", "\n")
     else:
-        post['text'] = ''
+        post["text"] = ""
 
     # Get the tags and categories
-    post['tags'] = list()
-    post['categories'] = list()
+    post["tags"] = list()
+    post["categories"] = list()
 
-    for element in node.getElementsByTagName('category'):
-        domain, name = element.getAttribute('domain'), element.getAttribute('nicename')
+    for element in node.getElementsByTagName("category"):
+        domain, name = element.getAttribute("domain"), element.getAttribute("nicename")
 
-        if name and domain and ('tag' in domain or 'category' in domain):
+        if name and domain and ("tag" in domain or "category" in domain):
             name = element.firstChild.data
-            domain = 'tags' if 'tag' in domain else 'categories'
+            domain = "tags" if "tag" in domain else "categories"
             post[domain].append(name)
 
     return post
+
 
 def xml_to_list(infile):
     """Return a list containing all the posts from the infile.
@@ -138,13 +140,13 @@ def xml_to_list(infile):
 
     dom = minidom.parse(infile)
 
-    blog = list() # list that will contain all posts
+    blog = list()  # list that will contain all posts
 
-    for node in dom.getElementsByTagName('item'):
+    for node in dom.getElementsByTagName("item"):
 
-        post = node_to_post( node )
+        post = node_to_post(node)
 
-        for domain in ['tags', 'categories']:
+        for domain in ["tags", "categories"]:
             post[domain] = sorted(set(post[domain]))
 
         # FIXME - wp:attachment_url could be use to download attachments
@@ -153,11 +155,12 @@ def xml_to_list(infile):
 
     return blog
 
+
 def link_to_file(link, post_name=None):
     """Gets filename from wordpress url."""
 
     name = None
-    check_for_letters = re.compile('[a-z]+', re.IGNORECASE)
+    check_for_letters = re.compile("[a-z]+", re.IGNORECASE)
     try:
         if (post_name != "") and (post_name is not None):
             if check_for_letters.match(post_name) is not None:
@@ -167,35 +170,37 @@ def link_to_file(link, post_name=None):
 
         if name is None:
             if "?p=" in link:
-                name = link.split('?p=')[-1]
+                name = link.split("?p=")[-1]
             else:
-                name = link.split('/')[-2]
+                name = link.split("/")[-2]
 
-        name = '%s.org' % unquote(name)
+        name = "%s.org" % unquote(name)
     # occasionally, some encoding errors may seep through
     except TypeError:
         logging.getLogger().debug("Error getting file link for %s, %s", link, post_name)
 
     return name
 
+
 def parse_date(date, date_format):
     """Change wp date format to a different format."""
 
     if date is not None:
-        date = date.split('+')[0].strip()
-        date = strptime(date, '%a, %d %b %Y %H:%M:%S')
+        date = date.split("+")[0].strip()
+        date = strptime(date, "%a, %d %b %Y %H:%M:%S")
         date = strftime(date_format, date)
 
         return date
 
+
 def blog_to_org(blog_list, name, level, separate_buffer, prefix):
     """Converts a blog-list into an org file."""
 
-    space = ' ' * level
-    stars = '*' * level
+    space = " " * level
+    stars = "*" * level
 
-    tag_sep = ', '
-    cat_sep = ', '
+    tag_sep = ", "
+    cat_sep = ", "
 
     template_parts = dict()
 
@@ -203,19 +208,19 @@ def blog_to_org(blog_list, name, level, separate_buffer, prefix):
         template = BUFFER_TEMPLATE
     else:
         template = SUBTREE_TEMPLATE
-        tag_sep = ':'
-        org_file = open('%s.org' % name, 'wb')
+        tag_sep = ":"
+        org_file = open("%s.org" % name, "wb")
 
     for post in blog_list:
-        post['tags'] = tag_sep.join(post['tags'])
-        if tag_sep == ':':
-            post['tags'] = ':' + post['tags'] + ':'
-        post['categories'] = cat_sep.join(post['categories'])
-        date_wp_fmt = post['date']
-        post['date'] = parse_date(date_wp_fmt, '[%Y-%m-%d %a %H:%M]')
+        post["tags"] = tag_sep.join(post["tags"])
+        if tag_sep == ":":
+            post["tags"] = ":" + post["tags"] + ":"
+        post["categories"] = cat_sep.join(post["categories"])
+        date_wp_fmt = post["date"]
+        post["date"] = parse_date(date_wp_fmt, "[%Y-%m-%d %a %H:%M]")
 
         if not separate_buffer:
-            post['text'] = post['text'].replace('\n', '\n %s' % space)
+            post["text"] = post["text"].replace("\n", "\n %s" % space)
 
         template_parts.update(**post)
         template_parts.update(space=space)
@@ -224,52 +229,68 @@ def blog_to_org(blog_list, name, level, separate_buffer, prefix):
 
         if separate_buffer:
             if prefix:
-                file_name = "%s-%s" % (parse_date(date_wp_fmt, '%Y-%m-%d'),
-                                       link_to_file(post['link'], post['post_name']))
+                file_name = "%s-%s" % (
+                    parse_date(date_wp_fmt, "%Y-%m-%d"),
+                    link_to_file(post["link"], post["post_name"]),
+                )
             else:
-                file_name = link_to_file(post['link'], post['post_name'])
+                file_name = link_to_file(post["link"], post["post_name"])
             if not os.path.exists(name):
                 os.mkdir(name)
             else:
-                org_file = open(os.path.join(name, file_name), 'wb')
-                org_file.write(post_output.encode('utf8'))
+                org_file = open(os.path.join(name, file_name), "wb")
+                org_file.write(post_output.encode("utf8"))
                 org_file.close()
         else:
-            org_file.write(post_output.encode('utf8'))
+            org_file.write(post_output.encode("utf8"))
 
     org_file.close()
 
+
 def main():
     parser = argparse.ArgumentParser(
-        description='Convert wordpress.xml to org2blog posts.')
+        description="Convert wordpress.xml to org2blog posts."
+    )
 
-    parser.add_argument('in_file', help='the input xml file exported from WP')
-    parser.add_argument('--buffer', action='store_true',
-                        help='enable to obtain a separate file for each post')
-    parser.add_argument('--prefix-date', action='store_true',
-                        help='prefix a date to the post files, when --buffer')
-    parser.add_argument('-l', '--level', type=int, default=1,
-                        help='level of the subtree when exporting to SUBTREE')
-    parser.add_argument('-o', '--out-file', default='org-posts',
-                        help='file or directory name for output')
+    parser.add_argument("in_file", help="the input xml file exported from WP")
+    parser.add_argument(
+        "--buffer",
+        action="store_true",
+        help="enable to obtain a separate file for each post",
+    )
+    parser.add_argument(
+        "--prefix-date",
+        action="store_true",
+        help="prefix a date to the post files, when --buffer",
+    )
+    parser.add_argument(
+        "-l",
+        "--level",
+        type=int,
+        default=1,
+        help="level of the subtree when exporting to SUBTREE",
+    )
+    parser.add_argument(
+        "-o",
+        "--out-file",
+        default="org-posts",
+        help="file or directory name for output",
+    )
 
     args = parser.parse_args()
 
-    logging_format = '%(message)s'
+    logging_format = "%(message)s"
     logging.basicConfig(format=logging_format, level=logging.INFO)
     logger = logging.getLogger()
-
 
     logger.warning("Parsing xml ...")
     blog_list = xml_to_list(args.in_file)
 
     logger.warning("Writing posts...")
-    blog_to_org(blog_list, args.out_file, args.level, args.buffer,
-                args.prefix_date)
+    blog_to_org(blog_list, args.out_file, args.level, args.buffer, args.prefix_date)
 
     logger.warning("Done!")
 
 
 if __name__ == "__main__":
     main()
-

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -105,7 +105,7 @@ def node_to_post(node):
     except ValueError:
         logging.getLogger().debug("Processing post #%s", post['id'])
 
-    if post['text'] != None:
+    if post['text'] is not None:
         post['text'] = post['text'].replace('\r\n', '\n')
         post['text'] = post['text'].replace('\n', '#$NEWLINE-MARKER$#')
         post['text'] = html_to_org(post['text'].encode('utf8')).decode('utf8')
@@ -158,7 +158,7 @@ def link_to_file(link):
 def parse_date(date, format):
     """Change wp date format to a different format."""
 
-    if date != None:
+    if date is not None:
         date = date.split('+')[0].strip()
         date = strptime(date, '%a, %d %b %Y %H:%M:%S')
         date = strftime(format, date)

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -111,10 +111,10 @@ def node_to_post(node):
     for element in node.getElementsByTagName('category'):
         domain, name = element.getAttribute('domain'), element.getAttribute('nicename')
 
-    if name and domain and ('tag' in domain or 'category' in domain):
-        name = element.firstChild.data
-        domain = 'tags' if 'tag' in domain else 'categories'
-        post[domain].append(name)
+        if name and domain and ('tag' in domain or 'category' in domain):
+            name = element.firstChild.data
+            domain = 'tags' if 'tag' in domain else 'categories'
+            post[domain].append(name)
 
     return post
 

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """wp_to_org2blog.py: Convert wordpress.xml to org2blog posts.
 

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -100,9 +100,9 @@ def node_to_post(node):
 
     try:
         if int(post['id']) % 10 == 0:
-            logging.getLogger().info("Processing post #%s" % post['id'])
+            logging.getLogger().info("Processing post #%s", post['id'])
     except ValueError:
-        logging.getLogger().debug("Processing post #%s" % post['id'])
+        logging.getLogger().debug("Processing post #%s", post['id'])
 
     if post['text'] != None:
         post['text'] = post['text'].replace('\r\n', '\n')

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -94,7 +94,7 @@ def node_to_post(node):
     try:
         if int(post['id']) % 10 == 0:
             logging.getLogger().info("Processing post #%s" % post['id'])
-    except:
+    except ValueError:
         logging.getLogger().debug("Processing post #%s" % post['id'])
 
     if post['text'] != None:

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -70,7 +70,7 @@ def html_to_org(html):
     proc = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
     output, error = proc.communicate(html)
 
-    if (proc.returncode != 0) or (error is not None):
+    if (proc.returncode != 0) or (error != b""):
         errormessage = """%s exited with return code %s and error %s when parsing:
             %s"""
         raise SubprocessError(errormessage % (args[0], proc.returncode, error, html))

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -165,7 +165,7 @@ def parse_date(date, date_format):
 
         return date
 
-def blog_to_org(blog_list, name, level, buffer, prefix):
+def blog_to_org(blog_list, name, level, separate_buffer, prefix):
     """Converts a blog-list into an org file."""
 
     space = ' ' * level
@@ -173,7 +173,7 @@ def blog_to_org(blog_list, name, level, buffer, prefix):
 
     tag_sep = cat_sep = ', '
 
-    if buffer:
+    if separate_buffer:
         template = BUFFER_TEMPLATE
     else:
         template = SUBTREE_TEMPLATE
@@ -188,12 +188,12 @@ def blog_to_org(blog_list, name, level, buffer, prefix):
         date_wp_fmt = post['date']
         post['date'] = parse_date(date_wp_fmt, '[%Y-%m-%d %a %H:%M]')
 
-        if not buffer:
+        if not separate_buffer:
             post['text'] = post['text'].replace('\n', '\n %s' % space)
 
         post_output = template % dict(post, **{'space': space, 'stars': stars})
 
-        if buffer:
+        if separate_buffer:
             if prefix:
                 file_name = "%s-%s" % (parse_date(date_wp_fmt, '%Y-%m-%d'),
                                        link_to_file(post['link']))

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -183,7 +183,7 @@ def blog_to_org(blog_list, name, level, separate_buffer, prefix):
     else:
         template = SUBTREE_TEMPLATE
         tag_sep = ':'
-        org_file = open('%s.org' % name, 'w')
+        org_file = open('%s.org' % name, 'wb')
 
     for post in blog_list:
         post['tags'] = tag_sep.join(post['tags'])
@@ -210,7 +210,7 @@ def blog_to_org(blog_list, name, level, separate_buffer, prefix):
             if not os.path.exists(name):
                 os.mkdir(name)
             else:
-                org_file = open(os.path.join(name, file_name), 'w')
+                org_file = open(os.path.join(name, file_name), 'wb')
                 org_file.write(post_output.encode('utf8'))
                 org_file.close()
         else:

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -155,13 +155,13 @@ def link_to_file(link):
     name = '%s.org' % unquote(name)
     return name
 
-def parse_date(date, format):
+def parse_date(date, date_format):
     """Change wp date format to a different format."""
 
     if date is not None:
         date = date.split('+')[0].strip()
         date = strptime(date, '%a, %d %b %Y %H:%M:%S')
-        date = strftime(format, date)
+        date = strftime(date_format, date)
 
         return date
 

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -61,10 +61,13 @@ BUFFER_TEMPLATE = u"""\
 
 def html_to_org(html):
     """Converts a html snippet to an org-snippet."""
+
     command = 'pandoc -r html -t org --wrap=none -'
     args = split(command)
+
     p = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
     output, error = p.communicate(html)
+
     if not error:
         return output
     else:
@@ -154,6 +157,7 @@ def parse_date(date, format):
         date = date.split('+')[0].strip()
         date = strptime(date, '%a, %d %b %Y %H:%M:%S')
         date = strftime(format, date)
+
         return date
 
 def blog_to_org(blog_list, name, level, buffer, prefix):

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -202,8 +202,6 @@ def blog_to_org(blog_list, name, level, buffer, prefix):
     f.close()
 
 if __name__ == "__main__":
-
-    import argparse
     parser = argparse.ArgumentParser(
         description='Convert wordpress.xml to org2blog posts.')
 

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -201,7 +201,7 @@ def blog_to_org(blog_list, name, level, buffer, prefix):
 
     f.close()
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(
         description='Convert wordpress.xml to org2blog posts.')
 
@@ -230,3 +230,7 @@ if __name__ == "__main__":
                 args.prefix_date)
 
     logger.warning("Done!")
+
+
+if __name__ == "__main__":
+    main()

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -30,7 +30,7 @@ import logging
 
 from time import strptime, strftime
 from xml.dom import minidom
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, SubprocessError
 from shlex import split
 from urllib.parse import unquote
 
@@ -68,10 +68,14 @@ def html_to_org(html):
     p = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
     output, error = p.communicate(html)
 
-    if not error:
-        return output
-    else:
-        raise Exception(error)
+    if (p.returncode != 0) or (error is not None):
+        errormessage = """%s exited with return code %s and error %s when parsing:
+            %s"""
+        raise SubprocessError(
+             errormessage % (args[0], p.returncode, error, html)
+        )
+
+    return output
 
 def get_firstChild_data(node, element):
     try:

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -24,6 +24,7 @@ __email__ = "punchagan@muse-amuse.in"
 
 
 import os
+import re
 import argparse
 import logging
 
@@ -94,7 +95,8 @@ def node_to_post(node):
         'date': 'pubDate',
         'author': 'dc:creator',
         'id': 'wp:post_id',
-        'text': 'content:encoded'
+        'text': 'content:encoded',
+        'post_name': 'wp:post_name'
     }
     post = dict()
 
@@ -151,10 +153,29 @@ def xml_to_list(infile):
 
     return blog
 
-def link_to_file(link):
+def link_to_file(link, post_name=None):
     """Gets filename from wordpress url."""
-    name = link.split('/')[-2]
-    name = '%s.org' % unquote(name)
+
+    name = None
+    check_for_letters = re.compile('[a-z]+', re.IGNORECASE)
+    try:
+        if (post_name != "") and (post_name is not None):
+            if check_for_letters.match(post_name) is not None:
+                name = post_name
+            else:
+                name = None
+
+        if name is None:
+            if "?p=" in link:
+                name = link.split('?p=')[-1]
+            else:
+                name = link.split('/')[-2]
+
+        name = '%s.org' % unquote(name)
+    # occasionally, some encoding errors may seep through
+    except TypeError:
+        logging.getLogger().debug("Error getting file link for %s, %s", link, post_name)
+
     return name
 
 def parse_date(date, date_format):
@@ -204,9 +225,9 @@ def blog_to_org(blog_list, name, level, separate_buffer, prefix):
         if separate_buffer:
             if prefix:
                 file_name = "%s-%s" % (parse_date(date_wp_fmt, '%Y-%m-%d'),
-                                       link_to_file(post['link']))
+                                       link_to_file(post['link'], post['post_name']))
             else:
-                file_name = link_to_file(post['link'])
+                file_name = link_to_file(post['link'], post['post_name'])
             if not os.path.exists(name):
                 os.mkdir(name)
             else:

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -139,7 +139,6 @@ def xml_to_list(infile):
     blog = list() # list that will contain all posts
 
     for node in dom.getElementsByTagName('item'):
-        post = dict()
 
         post = node_to_post( node )
 

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -31,6 +31,7 @@ import logging
 
 from time import strptime, strftime
 from xml.dom import minidom
+from xml.parsers.expat import ExpatError
 from subprocess import Popen, PIPE, SubprocessError
 from shlex import split
 from urllib.parse import unquote
@@ -138,7 +139,11 @@ def xml_to_list(infile):
     Each post is a dictionary.
     """
 
-    dom = minidom.parse(infile)
+    try:
+        dom = minidom.parse(infile)
+    except ExpatError as err:
+        print("Error while parsing %s: %s" % (infile, err))
+        raise
 
     blog = list()  # list that will contain all posts
 

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -78,6 +78,7 @@ def html_to_org(html):
     return output
 
 def get_firstChild_data(node, element):
+    """Try to retrieve the data contained at a node's firstChild element."""
     try:
         return node.getElementsByTagName(element)[0].firstChild.data
     except (AttributeError, IndexError):

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -142,7 +142,7 @@ def xml_to_list(infile):
     try:
         dom = minidom.parse(infile)
     except ExpatError as err:
-        print("Error while parsing %s: %s" % (infile, err))
+        logging.getLogger().debug("Error while parsing %s: %s", infile, err)
         raise
 
     blog = list()  # list that will contain all posts

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -116,7 +116,8 @@ def node_to_post(node):
         post['text'] = ''
 
     # Get the tags and categories
-    post['tags'], post['categories'] = [], []
+    post['tags'] = list()
+    post['categories'] = list()
 
     for element in node.getElementsByTagName('category'):
         domain, name = element.getAttribute('domain'), element.getAttribute('nicename')
@@ -135,7 +136,7 @@ def xml_to_list(infile):
 
     dom = minidom.parse(infile)
 
-    blog = [] # list that will contain all posts
+    blog = list() # list that will contain all posts
 
     for node in dom.getElementsByTagName('item'):
         post = dict()
@@ -173,7 +174,10 @@ def blog_to_org(blog_list, name, level, separate_buffer, prefix):
     space = ' ' * level
     stars = '*' * level
 
-    tag_sep = cat_sep = ', '
+    tag_sep = ', '
+    cat_sep = ', '
+
+    template_parts = dict()
 
     if separate_buffer:
         template = BUFFER_TEMPLATE
@@ -193,7 +197,10 @@ def blog_to_org(blog_list, name, level, separate_buffer, prefix):
         if not separate_buffer:
             post['text'] = post['text'].replace('\n', '\n %s' % space)
 
-        post_output = template % dict(post, **{'space': space, 'stars': stars})
+        template_parts.update(**post)
+        template_parts.update(space=space)
+        template_parts.update(stars=stars)
+        post_output = template % template_parts
 
         if separate_buffer:
             if prefix:

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -32,7 +32,7 @@ from time import strptime, strftime
 from xml.dom import minidom
 from subprocess import Popen, PIPE
 from shlex import split
-from urllib2 import unquote
+from urllib.parse import unquote
 
 SUBTREE_TEMPLATE = u"""\
 %(stars)s %(title)s %(tags)s

--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -109,7 +109,7 @@ def node_to_post(node):
         if int(post["id"]) % 10 == 0:
             logging.getLogger().info("Processing post #%s", post["id"])
     except ValueError:
-        logging.getLogger().debug("Processing post #%s", post["id"])
+        logging.getLogger().warning("Processing post #%s", post["id"])
 
     if post["text"] is not None:
         post["text"] = post["text"].replace("\r\n", "\n")
@@ -142,7 +142,7 @@ def xml_to_list(infile):
     try:
         dom = minidom.parse(infile)
     except ExpatError as err:
-        logging.getLogger().debug("Error while parsing %s: %s", infile, err)
+        logging.getLogger().error("Error while parsing %s: %s", infile, err)
         raise
 
     blog = list()  # list that will contain all posts
@@ -182,7 +182,9 @@ def link_to_file(link, post_name=None):
         name = "%s.org" % unquote(name)
     # occasionally, some encoding errors may seep through
     except TypeError:
-        logging.getLogger().debug("Error getting file link for %s, %s", link, post_name)
+        logging.getLogger().warning(
+            "Error getting file link for %s, %s", link, post_name
+        )
 
     return name
 
@@ -288,13 +290,13 @@ def main():
     logging.basicConfig(format=logging_format, level=logging.INFO)
     logger = logging.getLogger()
 
-    logger.warning("Parsing xml ...")
+    logger.info("Parsing xml ...")
     blog_list = xml_to_list(args.in_file)
 
-    logger.warning("Writing posts...")
+    logger.info("Writing posts...")
     blog_to_org(blog_list, args.out_file, args.level, args.buffer, args.prefix_date)
 
-    logger.warning("Done!")
+    logger.info("Done!")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #7.

List of changes:

- changed logger levels to reflect their function
- changed from print to logger debug
- added try statement to catch malformed XML
- corrected to compare to regular binary empty string
- reformatted with black
- changed shebang to use python3
- added newline at end of file
- added check for post query ('?p=123') in URL
- fixed builtins.TypeError: must be str, not bytes
- removed redundant variable assignment
- switched to more verbose instructions
- clarified variable names and used snake_case
- avoided using (py2) buffer builtin function name
- avoided using format builtin function name
- fixed None comparisons
- added get_firstChild_data docstring
- corrected lazy formatting for logger
- checked non-0 return codes or SubprocessErrors
- added newlines for readability
- fixed indentation logic
- added exception type
- moved main actions into main function
- stopped argparse from being re-imported
- Used urllib.parse instead of urllib2